### PR TITLE
Chore/async await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+- 12
 - 10
 - 8
-- 6
 after_success:
 - npm i -g nyc coveralls
 - nyc npm test && nyc report --reporter=text-lcov | coveralls

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   },
   "dependencies": {
     "dat-link-resolve": "^2.3.0",
-    "dat-node": "^3.5.14",
+    "dat-node": "^3.5.15",
     "mkdirp": "^0.5.1",
     "rimraf": "^3.0.0"
   },
   "devDependencies": {
-    "standard": "^13.0.1",
-    "mocha": "^6.0.0"
+    "standard": "^14.3.1",
+    "mocha": "^6.2.2"
   },
   "author": "Diana Thayer <garbados@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR updates some dependencies and refactors DatLibrarian's async methods to use the async/await syntax. This has resulted in less indentation, which makes the code a bit clearer. The test suite is unchanged because the library's API is unchanged.